### PR TITLE
Add extended normalisation options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ htmlcov
 .project
 .pydevproject
 
+# IntelliJ
+*.iml
+.idea
+
 # Complexity
 output/*.html
 output/*/index.html


### PR DESCRIPTION
I added some modifications to your magnificent program to automatically normalize several media files at once.
I added some modifications to perfectly match my needs and I wanted to share those with you. It's not a request to you to add all of these features, it's just that some of them might be handy for other users as well.
- add program option to write output in a separate directory in stead of prefixing it, making it easier to handle the modfied files.
- add program option to merge the normalized audio in the original (video) file rather than creating a separate WAV file
- change the maximum setting: will now normalize so that max. **This is one that you might want to review. I wanted the option to handle the audio using the maximum volume**
   e.g. : -m -l -5 will increase the audio level to max = -5.0dB
- improve verbose logging: number of files are written to the info log and I changed some "warning" loggings to "info" loggings
- improve performance: check first whether the output file exists before calculating the volume levels + not modifying the file if the adjustment < 0.5dB (level is never exactly 0 so if you run the app twice, most files will be processed while none of them are actually modified)